### PR TITLE
Fix hard coded user/group names in config manifest

### DIFF
--- a/manifests/config/file.pp
+++ b/manifests/config/file.pp
@@ -28,8 +28,8 @@ define fluentd::config::file (
   file { $config_path:
     ensure  => $ensure,
     content => $content,
-    owner   => 'td-agent',
-    group   => 'td-agent',
+    owner   => $::fluentd::user_name,
+    group   => $::fluentd::user_group,
     mode    => '0644',
     notify  => Class['Fluentd::Service'],
   }


### PR DESCRIPTION
Just a simple PR to use $fluentd::user_name and user_group commands in the fluentd::config::file resource. 