### PR TITLE
migrate from stdlib validation to puppet datatypes

### DIFF
--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -38,23 +38,16 @@
 # Copyright 2015 wywy, unless otherwise noted.
 #
 define fluentd::filter (
-  $ensure   = present,
-  $priority = 20,
-  $pattern  = '**',
-  $config   = {},
+  Enum['present', 'absent'] $ensure   = present,
+  Integer                   $priority = 20,
+  String                    $pattern  = '**',
+  Hash                      $config   = {},
 ) {
-
-  # parameter validation
-  if ! ($ensure in [ 'present', 'absent' ]) {
-    fail('ensure parameter must be present or absent')
-  }
-  validate_integer($priority)
-  validate_string($pattern)
-  validate_hash($config)
 
   fluentd::config::file { "filter-${title}":
     ensure   => $ensure,
     priority => $priority,
     content  => template( 'fluentd/filter.erb'),
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,36 +65,23 @@
 # Copyright 2015 wywy, unless otherwise noted.
 #
 class fluentd (
-  $repo_manage             = $::fluentd::params::repo_manage,
-  $package_ensure          = $::fluentd::params::package_ensure,
-  $package_name            = $::fluentd::params::package_name,
-  $package_install_options = $::fluentd::params::package_install_options,
-  $service_manage          = $::fluentd::params::service_manage,
-  $service_name            = $::fluentd::params::service_name,
-  $service_ensure          = $::fluentd::params::service_ensure,
-  $service_enable          = $::fluentd::params::service_enable,
-  $config_path             = $::fluentd::params::config_path,
-  $conf_dir                = $::fluentd::params::conf_dir,
-  $config_file             = $::fluentd::params::config_file,
-  $conf_dir_manage         = $::fluentd::params::conf_dir_manage,
-  $user_manage             = $::fluentd::params::user_manage,
-  $user_name               = $::fluentd::params::user_name,
-  $user_group              = $::fluentd::params::user_group,
-  $user_groups             = $::fluentd::params::user_groups,
+  Boolean                     $repo_manage             = $::fluentd::params::repo_manage,
+  String                      $package_ensure          = $::fluentd::params::package_ensure,
+  String                      $package_name            = $::fluentd::params::package_name,
+  Array                       $package_install_options = $::fluentd::params::package_install_options,
+  Boolean                     $service_manage          = $::fluentd::params::service_manage,
+  String                      $service_name            = $::fluentd::params::service_name,
+  Enum['running', 'stopped']  $service_ensure          = $::fluentd::params::service_ensure,
+  Boolean                     $service_enable          = $::fluentd::params::service_enable,
+  String                      $config_path             = $::fluentd::params::config_path,
+  String                      $conf_dir                = $::fluentd::params::conf_dir,
+  String                      $config_file             = $::fluentd::params::config_file,
+  Boolean                     $conf_dir_manage         = $::fluentd::params::conf_dir_manage,
+  Boolean                     $user_manage             = $::fluentd::params::user_manage,
+  String                      $user_name               = $::fluentd::params::user_name,
+  String                      $user_group              = $::fluentd::params::user_group,
+  Array                       $user_groups             = $::fluentd::params::user_groups,
 ) inherits fluentd::params {
-
-  # parameter validation
-  validate_bool($repo_manage)
-  validate_string($package_ensure)
-  validate_string($package_name)
-  validate_array($package_install_options)
-  validate_bool($service_manage)
-  validate_string($service_name)
-  validate_bool($service_enable)
-
-  if ! ($service_ensure in [ 'running', 'stopped' ]) {
-    fail('service_ensure parameter must be running or stopped')
-  }
 
   # class calls
   include '::fluentd::repo'

--- a/manifests/match.pp
+++ b/manifests/match.pp
@@ -43,23 +43,16 @@
 # Copyright 2015 wywy, unless otherwise noted.
 #
 define fluentd::match (
-  $ensure   = present,
-  $priority = 30,
-  $pattern  = '**',
-  $config   = {},
+  Enum['present', 'absent'] $ensure   = present,
+  Integer                   $priority = 30,
+  String                    $pattern  = '**',
+  Hash                      $config   = {},
 ) {
-
-  # parameter validation
-  if ! ($ensure in [ 'present', 'absent' ]) {
-    fail('ensure parameter must be present or absent')
-  }
-  validate_integer($priority)
-  validate_string($pattern)
-  validate_hash($config)
 
   fluentd::config::file { "match-${title}":
     ensure   => $ensure,
     priority => $priority,
     content  => template( 'fluentd/match.erb'),
   }
+
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,9 +26,9 @@
 # Copyright 2015 wywy, unless otherwise noted.
 #
 define fluentd::plugin (
-  $ensure = present,
-  $type   = 'gem',
-  $source = undef,
+  String           $ensure = present,
+  String           $type   = 'gem',
+  Optional[String] $source = undef,
 ) {
 
   case $type {
@@ -43,7 +43,6 @@ define fluentd::plugin (
       if ! ($ensure in [ 'present', 'absent' ]) {
         fail('ensure parameter must be present or absent')
       }
-      validate_string($source)
 
       fluentd::plugin::file { $name:
         ensure  => $ensure,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -34,17 +34,15 @@
 # Copyright 2015 wywy, unless otherwise noted.
 #
 define fluentd::source (
-  $ensure   = present,
-  $priority = 10,
-  $config   = {},
+  String  $ensure   = present,
+  Integer $priority = 10,
+  Hash    $config   = {},
 ) {
 
   # parameter validation
   if ! ($ensure in [ 'present', 'absent' ]) {
     fail('ensure parameter must be present or absent')
   }
-  validate_integer($priority)
-  validate_hash($config)
 
   fluentd::config::file { "source-${title}":
     ensure   => $ensure,


### PR DESCRIPTION
fixes some puppet 4 deprecation warnings caused by stdlib